### PR TITLE
fix: null owner address means unknown

### DIFF
--- a/pkg/gen/models/response_wrapper_token_security.go
+++ b/pkg/gen/models/response_wrapper_token_security.go
@@ -274,7 +274,7 @@ type ResponseWrapperTokenSecurityResultAnon struct {
 	// (2) Sometimes, when "is_proxy": "1", there will be no return.
 	// (3) Ownership is mostly used to adjust the parameters and status of the contract, such as minting, modification of slippage, suspension of trading, setting blacklist, etc.
 	// When the contract does not have an owner (or if the owner is a black hole address) and the owner cannot be retrieved, these functions will most likely be disabled.)
-	OwnerAddress string `json:"owner_address,omitempty"`
+	OwnerAddress *string `json:"owner_address,omitempty"`
 
 	// It describes the balance of the contract owner.
 	// Example: "owner_balance": "100000000".


### PR DESCRIPTION
This field owner address: 

// No return means unknown; Return empty means there is no ownership or can't find ownership.(Notice:(1) When "is_open_source": "0", there will be no return.


This PR aims to fix the case that former version can not identify these two situations: 
1. no return
2. return empty


In former version these two situation would exactly be the same. So type of `OwnerAddress` should be pointer. 

